### PR TITLE
get thing-at-point as initial input when query the from string

### DIFF
--- a/anzu.el
+++ b/anzu.el
@@ -522,7 +522,7 @@
                                  (anzu--check-minibuffer-input
                                   curbuf beg end use-regexp overlay-limit))))))
           (prog1 (read-from-minibuffer (format "%s: " prompt)
-                                       nil nil nil 'anzu--history nil t)
+                                       (thing-at-point 'symbol) nil nil 'anzu--history nil t)
             (setq is-input t)))
       (when timer
         (cancel-timer timer)


### PR DESCRIPTION
Hi,

I created a simple PR to allow using the current symbol at point as an initial input of query-replace.

Currently, the `from string` is  empty by default, and most of the time, users may want to search and replace the current symbol at point.

This PR can help to avoid typing the current symbols.

Can you review and consider merging the PR?

Thanks!


